### PR TITLE
Remove annotation processor for Log4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,10 @@ clean.doFirst {
     delete "${rootDir}/target"
 }
 
+compileJava {
+    options.compilerArgs += '-proc:none'
+}
+
 task copyRunner(type: Copy) {
     into "$buildDir/server"
     from(configurations.compile) {


### PR DESCRIPTION
This is not used unless plug-ins are used.