### PR TITLE
Remove use of deprecated integer constructor

### DIFF
--- a/src/main/java/com/battlesnake/game/Board.java
+++ b/src/main/java/com/battlesnake/game/Board.java
@@ -32,7 +32,7 @@ public class Board {
         TAIL;
 
         public String toString() {
-            return new Integer(this.ordinal()).toString();
+            return Integer.valueOf(this.ordinal()).toString();
         }
     }
 


### PR DESCRIPTION
`new Integer(int)` is deprecated in Java 9